### PR TITLE
Hack (DO NOT SUBMIT): show which texts have word-by-word parse

### DIFF
--- a/ambuda/templates/texts/index.html
+++ b/ambuda/templates/texts/index.html
@@ -4,7 +4,7 @@
 <ul>
   {% for text in texts %}
   {% set url = url_for('texts.text', slug=text.slug) %}
-  <li><a class="py-1 block text-2xl hover:underline" href="{{ url }}">{{ text.title | devanagari }}</a></li>
+  <li><a class="py-1 block text-2xl hover:underline" href="{{ url }}">{{'*' if text.has_any_parse}} {{ text.title | devanagari }}</a></li>
   {% endfor %}
 </ul> 
 {% endmacro %}
@@ -18,6 +18,8 @@
   <p>Our main focus right now is on building out the core features of our
   library. Once those features are in place, we will radically increase the
   size and quality of our collection.</p>
+
+  <p>Texts with word-by-word meaning are indicated with (*).</p>
 </div>
 
 {{ text_list(texts) }}

--- a/ambuda/views/texts.py
+++ b/ambuda/views/texts.py
@@ -53,6 +53,13 @@ def _hk_to_dev(s: str) -> str:
 def index():
     """Show all texts."""
     all_texts = q.texts()
+    # session.query(db.BlockParse).filter_by(block_id=block_id).first()
+    parsed_texts = q.get_session().execute("SELECT DISTINCT text_id FROM block_parses")
+    parsed_texts = set(t[0] for t in parsed_texts)
+    print(parsed_texts)
+    for text in all_texts:
+        if text.id in parsed_texts:
+            text.has_any_parse = True
     all_texts = sorted(all_texts, key=lambda t: _hk_to_dev(t.title))
     return render_template("texts/index.html", texts=all_texts)
 


### PR DESCRIPTION
This implementation is a hack and I don't want this to be merged, but creating this PR to start a discussion / for some guidance. The problem intended to be solved is that right now, the website looks "broken" in the sense that for most of the texts, we don't yet have parse data, so it would be good to highlight this somehow (and draw readers' attention to the texts for which we _do_ have parse data, so that they can see the value / come back for more).

Although the plan is to have a Sanskrit parser and soon have parse data for every text, it's still likely that there will be some texts with parse data, and some without. In terms of implementation, I think it would be good to have something on the `Text` model that stores whether it has any parse data or not. This implementation (running raw SQL in the query path) is surely not how to do it, but hopefully someone can point out how to do it :-)

Then when we have it, we could:

1.  on the https://ambuda.org/texts/ page, highlight the texts for which there is parse data,

    <img width="647" alt="image" src="https://user-images.githubusercontent.com/767530/178495933-013da245-daab-4235-8e05-72f0de4a29e9.png">

1.  on a given text section page like https://ambuda.org/texts/rtusamharam/1,

    <img width="587" alt="image" src="https://user-images.githubusercontent.com/767530/178497590-f3d1f81c-50ba-49f3-bed1-df3ed4b12d57.png">

    modify the "click on words to see what they mean", to mention that this feature is not available for this text yet, but will be later, and meanwhile is available for other texts,

1.  when a given text block is clicked, then in the error message,

    <img width="587" alt="image" src="https://user-images.githubusercontent.com/767530/178498202-d92eb81e-dadf-4e12-b966-4439013f9a03.png">

    instead of saying "server error" (which seems like something transient and the user should try again) say definitively that no parse data is available for this text at all.
