### PR TITLE
Introduce basic CI for python tests.

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -1,0 +1,35 @@
+name: 'Basic (Unit) Tests'
+
+# **What it does**: Setups up python dependencies and runs tests.
+# **Why we have it**: Automatically run tests to ensure code doesn't introduce regressions.
+# **Who does it impact**: Python small-scale "unit" tests.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.x'
+
+      - name: Install dependencies
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Run Tests
+        run: make test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Unit Tests](https://github.com/ambuda-project/ambuda/actions/workflows/basic-tests.yml/badge.svg)
+
 Ambuda
 ======
 


### PR DESCRIPTION
Address #16.

Runs on pull requests, pushes to main, and manual invocations.

The badge will appear as a broken link until this is run on main. View [this](https://github.com/theFestest/ambuda/actions/workflows/basic-tests.yml/badge.svg?branch=introduce-ci) on my fork to see how it should look instead.

For now its just the python unit tests, but can serve as a model for addition additional lints, code coverage reports, etc. Let me know if you intended the initial CI to include anything else.

View the "checks" tab under this test PR to see the results. https://github.com/theFestest/ambuda/pull/1