### PR TITLE
Refactor proofing utils and rename text download box

### DIFF
--- a/ambuda/templates/proofing/project.html
+++ b/ambuda/templates/proofing/project.html
@@ -10,7 +10,7 @@
 
 <p class="my-4 text-sm pb-4">
 Download as:
-<a class="btn bg-slate-100 hover:bg-slate-200" href="{{ url_for("proofing.download_as_text", slug=project.slug) }}">text</a>
+<a class="btn bg-slate-100 hover:bg-slate-200" href="{{ url_for("proofing.download_as_text", slug=project.slug) }}">Text</a>
 <a class="btn bg-slate-100 hover:bg-slate-200" href="{{ url_for("proofing.download_as_xml", slug=project.slug) }}">XML</a>
 </p>
 

--- a/ambuda/utils/proofing_utils.py
+++ b/ambuda/utils/proofing_utils.py
@@ -21,26 +21,26 @@ TEI_HEADER_BOILERPLATE = """
 """.strip()
 
 
+def transform_blob_to_page(blob: str) -> str:
+    """Parses blob into text as page (linebreaks removed)."""
+    page_buf = []
+    for line in blob.splitlines():
+        line = line.strip()
+        # Join hyphens
+        if line.endswith("-"):
+            page_buf.append(line[:-1])
+        else:
+            # FIXME: we should also join lines if a paragraph, but we
+            # can reliably separate paragraphs/verses only if there's
+            # markup.
+            page_buf.append(line)
+            page_buf.append("\n")
+    return "".join(page_buf)
+
+
 def to_plain_text(blobs: list[str]) -> str:
     """Publish a project as plain text."""
-    buf = []
-    for i, blob in enumerate(blobs):
-        page_number = i + 1
-        page_buf = []
-        for line in blob.splitlines():
-            line = line.strip()
-            # Join hyphens
-            if line.endswith("-"):
-                page_buf.append(line[:-1])
-            else:
-                # FIXME: we should also join lines if a paragraph, but we
-                # can reliably separate paragraphs/verses only if there's
-                # markup.
-                page_buf.append(line)
-                page_buf.append("\n")
-        clean_page_content = "".join(page_buf)
-        buf.append(clean_page_content)
-    return "\n\n".join(buf)
+    return "\n\n".join([transform_blob_to_page(b) for b in blobs])
 
 
 def to_tei_xml(blobs: list[str]) -> str:
@@ -50,19 +50,7 @@ def to_tei_xml(blobs: list[str]) -> str:
     for i, blob in enumerate(blobs):
         page_number = i + 1
         buf.append(f'<pb n="{page_number}" />')
-        page_buf = []
-        for line in blob.splitlines():
-            line = line.strip()
-            # Join hyphens
-            if line.endswith("-"):
-                page_buf.append(line[:-1])
-            else:
-                # FIXME: we should also join lines if a paragraph, but we
-                # can reliably separate paragraphs/verses only if there's
-                # markup.
-                page_buf.append(line)
-                page_buf.append("\n")
-        clean_page_content = "".join(page_buf)
+        clean_page_content = transform_blob_to_page(blob)
         buf.append(clean_page_content)
 
     buf.append("</body></text></TEI>")


### PR DESCRIPTION
The functions for xml and plaintext were duplicated, this cleaning
abstracts the duplicated logic. The text box's lack of capitalization
seemed inappropriate next to the full caps of the XML download box.