### PR TITLE
Remove more dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,6 @@ google-auth==2.9.0
 google-cloud-vision==2.7.3
 googleapis-common-protos==1.56.3
 greenlet==1.1.2
-grpcio==1.47.0
-grpcio-status==1.47.0
 gunicorn==20.1.0
 h11==0.13.0
 idna==3.3
@@ -55,7 +53,6 @@ Jinja2==3.1.2
 kombu==5.2.4
 langcodes==3.3.0
 language-data==1.1
-lxml==4.9.1
 Mako==1.2.0
 marisa-trie==0.7.7
 markdown-it-py==2.1.0


### PR DESCRIPTION
When setting up Ambuda dev environment from scratch, these dependencies (grpc, lxml) take the longest to download and install, but as far as I can tell (based on text search of the repo's code) they are not actually used. (How to check?)