### PR TITLE
Support SARIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ db_seed_all:
 	python -m ambuda.seed.lookup.role
 	python -m ambuda.seed.lookup.page_status
 	python -m ambuda.seed.texts.gretil
+	python -m ambuda.seed.texts.sarit
 	python -m ambuda.seed.texts.ramayana
 	python -m ambuda.seed.texts.mahabharata
 	python -m ambuda.seed.dcs

--- a/ambuda/consts.py
+++ b/ambuda/consts.py
@@ -19,7 +19,6 @@ TEXT_CATEGORIES = {
         "hamsadutam",
     ],
     "anye": [
-        "bodhicaryavatara",
-        "ayurvedasutram"
+        "bodhicaryavatara"
     ],
 }

--- a/ambuda/consts.py
+++ b/ambuda/consts.py
@@ -20,5 +20,6 @@ TEXT_CATEGORIES = {
     ],
     "anye": [
         "bodhicaryavatara",
+        "ayurvedasutram"
     ],
 }

--- a/ambuda/seed/texts/gretil.py
+++ b/ambuda/seed/texts/gretil.py
@@ -57,15 +57,15 @@ NS = {
 }
 
 
-def fetch_latest_data():
+def fetch_latest_data(repo: str, data_dir: str):
     """Fetch the latest data from our GitHub repo."""
-    if not DATA_DIR.exists():
-        subprocess.run(f"mkdir -p {DATA_DIR}", shell=True)
-        subprocess.run(f"git clone --branch=main {REPO} {DATA_DIR}", shell=True)
+    if not data_dir.exists():
+        subprocess.run(f"mkdir -p {data_dir}", shell=True)
+        subprocess.run(f"git clone --branch=main {repo} {data_dir}", shell=True)
 
-    subprocess.call("git fetch origin", shell=True, cwd=DATA_DIR)
-    subprocess.call("git checkout main", shell=True, cwd=DATA_DIR)
-    subprocess.call("git reset --hard origin/main", shell=True, cwd=DATA_DIR)
+    subprocess.call("git fetch origin", shell=True, cwd=data_dir)
+    subprocess.call("git checkout main", shell=True, cwd=data_dir)
+    subprocess.call("git reset --hard origin/main", shell=True, cwd=data_dir)
 
 
 @dataclass
@@ -191,9 +191,9 @@ def parse_tei_document(xml: ET.Element) -> Document:
     return Document(header=header_blob, sections=sections)
 
 
-def add_document(engine, spec: Spec):
+def add_document(engine, data_dir: str, spec: Spec):
     log(f"Writing text: {spec.slug}")
-    document_path = DATA_DIR / "1_sanskr" / "tei" / spec.filename
+    document_path = data_dir / spec.filename
 
     delete_existing_text(engine, spec.slug)
     with Session(engine) as session:
@@ -227,13 +227,13 @@ def add_document(engine, spec: Spec):
 
 def run():
     log("Downloading the latest data ...")
-    fetch_latest_data()
+    fetch_latest_data(REPO, DATA_DIR)
 
     log("Initializing database ...")
     engine = create_db()
 
     for spec in ALLOW:
-        add_document(engine, spec)
+        add_document(engine, DATA_DIR / "1_sanskr" / "tei", spec)
     log("Done.")
 
 

--- a/ambuda/seed/texts/sarit.py
+++ b/ambuda/seed/texts/sarit.py
@@ -1,0 +1,29 @@
+"""Parse Sanskrit texts from SARIT.
+
+"""
+from ambuda.seed.texts.gretil import *
+
+
+REPO = "https://github.com/sarit/SARIT-corpus.git"
+BRANCH = "master"
+PROJECT_DIR = Path(__file__).resolve().parents[3]
+DATA_DIR = PROJECT_DIR / "data" / "ambuda-sarit"
+
+ALLOW = [
+
+]
+
+def run():
+    log("Downloading the latest data ...")
+    fetch_latest_data(REPO, BRANCH, DATA_DIR)
+
+    log("Initializing database ...")
+    engine = create_db()
+
+    for spec in ALLOW:
+        add_document(engine, DATA_DIR, spec)
+    log("Done.")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
- Add sarit.py to import from SARIT
- Make gretil.py more generic so its functions can be reused by sarit parsing code. In a future PR, I will move these functions to a "tei_utils.py" file.